### PR TITLE
upgrade golang version at Dockerfile according to version from go.mod

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-FROM golang:1.12-alpine AS build
+FROM golang:1.13-alpine AS build
 
 ARG VERSION
 ARG GOPROXY


### PR DESCRIPTION
Repairs `docker build .` command. It was broken since go.mod version was [changed](https://github.com/i-core/werther/commit/949b123e92f06b912eb33e3b6c1607732cffffc9) 