### PR TITLE
identp: Fake TLS termination

### DIFF
--- a/internal/hydra/consent.go
+++ b/internal/hydra/consent.go
@@ -13,18 +13,19 @@ import (
 
 // ConsentReqDoer fetches information on the OAuth2 request and then accept or reject the requested authentication process.
 type ConsentReqDoer struct {
-	hydraURL    string
-	rememberFor int
+	hydraURL           string
+	fakeTlsTermination bool
+	rememberFor        int
 }
 
 // NewConsentReqDoer creates a ConsentRequest.
-func NewConsentReqDoer(hydraURL string, rememberFor int) *ConsentReqDoer {
-	return &ConsentReqDoer{hydraURL: hydraURL, rememberFor: rememberFor}
+func NewConsentReqDoer(hydraURL string, fakeTlsTermination bool, rememberFor int) *ConsentReqDoer {
+	return &ConsentReqDoer{hydraURL: hydraURL, fakeTlsTermination: fakeTlsTermination, rememberFor: rememberFor}
 }
 
 // InitiateRequest fetches information on the OAuth2 request.
 func (crd *ConsentReqDoer) InitiateRequest(challenge string) (*ReqInfo, error) {
-	ri, err := initiateRequest(consent, crd.hydraURL, challenge)
+	ri, err := initiateRequest(consent, crd.hydraURL, crd.fakeTlsTermination, challenge)
 	return ri, errors.Wrap(err, "failed to initiate consent request")
 }
 

--- a/internal/hydra/consent.go
+++ b/internal/hydra/consent.go
@@ -47,6 +47,6 @@ func (crd *ConsentReqDoer) AcceptConsentRequest(challenge string, remember bool,
 			IDToken: idToken,
 		},
 	}
-	redirectURI, err := acceptRequest(consent, crd.hydraURL, challenge, data)
+	redirectURI, err := acceptRequest(consent, crd.hydraURL, crd.fakeTlsTermination, challenge, data)
 	return redirectURI, errors.Wrap(err, "failed to accept consent request")
 }

--- a/internal/hydra/consent.go
+++ b/internal/hydra/consent.go
@@ -14,18 +14,18 @@ import (
 // ConsentReqDoer fetches information on the OAuth2 request and then accept or reject the requested authentication process.
 type ConsentReqDoer struct {
 	hydraURL           string
-	fakeTlsTermination bool
+	fakeTLSTermination bool
 	rememberFor        int
 }
 
 // NewConsentReqDoer creates a ConsentRequest.
-func NewConsentReqDoer(hydraURL string, fakeTlsTermination bool, rememberFor int) *ConsentReqDoer {
-	return &ConsentReqDoer{hydraURL: hydraURL, fakeTlsTermination: fakeTlsTermination, rememberFor: rememberFor}
+func NewConsentReqDoer(hydraURL string, fakeTLSTermination bool, rememberFor int) *ConsentReqDoer {
+	return &ConsentReqDoer{hydraURL: hydraURL, fakeTLSTermination: fakeTLSTermination, rememberFor: rememberFor}
 }
 
 // InitiateRequest fetches information on the OAuth2 request.
 func (crd *ConsentReqDoer) InitiateRequest(challenge string) (*ReqInfo, error) {
-	ri, err := initiateRequest(consent, crd.hydraURL, crd.fakeTlsTermination, challenge)
+	ri, err := initiateRequest(consent, crd.hydraURL, crd.fakeTLSTermination, challenge)
 	return ri, errors.Wrap(err, "failed to initiate consent request")
 }
 
@@ -47,6 +47,6 @@ func (crd *ConsentReqDoer) AcceptConsentRequest(challenge string, remember bool,
 			IDToken: idToken,
 		},
 	}
-	redirectURI, err := acceptRequest(consent, crd.hydraURL, crd.fakeTlsTermination, challenge, data)
+	redirectURI, err := acceptRequest(consent, crd.hydraURL, crd.fakeTLSTermination, challenge, data)
 	return redirectURI, errors.Wrap(err, "failed to accept consent request")
 }

--- a/internal/hydra/consent_test.go
+++ b/internal/hydra/consent_test.go
@@ -55,7 +55,7 @@ func TestInitiateConsentRequest(t *testing.T) {
 			h := &testInitiateConsentHandler{reqInfo: tc.reqInfo, status: tc.status}
 			srv := httptest.NewServer(h)
 			defer srv.Close()
-			ldr := hydra.NewConsentReqDoer(srv.URL, tc.rememberFor)
+			ldr := hydra.NewConsentReqDoer(srv.URL, false, tc.rememberFor)
 
 			reqInfo, err := ldr.InitiateRequest(tc.challenge)
 
@@ -149,7 +149,7 @@ func TestAcceptConsentRequest(t *testing.T) {
 			h := &testAcceptConsentHandler{challenge: tc.challenge, status: tc.status, redirect: tc.redirect}
 			srv := httptest.NewServer(h)
 			defer srv.Close()
-			ldr := hydra.NewConsentReqDoer(srv.URL, tc.rememberFor)
+			ldr := hydra.NewConsentReqDoer(srv.URL, false, tc.rememberFor)
 
 			var grantScope []string
 			for _, v := range tc.grantScope {

--- a/internal/hydra/hydra.go
+++ b/internal/hydra/hydra.go
@@ -44,7 +44,7 @@ type ReqInfo struct {
 	Subject         string   `json:"subject"`
 }
 
-func initiateRequest(typ reqType, hydraURL string, fakeTlsTermination bool, challenge string) (*ReqInfo, error) {
+func initiateRequest(typ reqType, hydraURL string, fakeTLSTermination bool, challenge string) (*ReqInfo, error) {
 	if challenge == "" {
 		return nil, ErrChallengeMissed
 	}
@@ -62,7 +62,7 @@ func initiateRequest(typ reqType, hydraURL string, fakeTlsTermination bool, chal
 	if err != nil {
 		return nil, err
 	}
-	if fakeTlsTermination {
+	if fakeTLSTermination {
 		req.Header.Add("X-Forwarded-Proto", "https")
 	}
 
@@ -85,7 +85,7 @@ func initiateRequest(typ reqType, hydraURL string, fakeTlsTermination bool, chal
 	return &ri, nil
 }
 
-func acceptRequest(typ reqType, hydraURL string, fakeTlsTermination bool, challenge string, data interface{}) (string, error) {
+func acceptRequest(typ reqType, hydraURL string, fakeTLSTermination bool, challenge string, data interface{}) (string, error) {
 	if challenge == "" {
 		return "", ErrChallengeMissed
 	}
@@ -110,7 +110,7 @@ func acceptRequest(typ reqType, hydraURL string, fakeTlsTermination bool, challe
 	if err != nil {
 		return "", err
 	}
-	if fakeTlsTermination {
+	if fakeTLSTermination {
 		r.Header.Add("X-Forwarded-Proto", "https")
 	}
 

--- a/internal/hydra/hydra.go
+++ b/internal/hydra/hydra.go
@@ -85,7 +85,7 @@ func initiateRequest(typ reqType, hydraURL string, fakeTlsTermination bool, chal
 	return &ri, nil
 }
 
-func acceptRequest(typ reqType, hydraURL, challenge string, data interface{}) (string, error) {
+func acceptRequest(typ reqType, hydraURL string, fakeTlsTermination bool, challenge string, data interface{}) (string, error) {
 	if challenge == "" {
 		return "", ErrChallengeMissed
 	}
@@ -110,6 +110,10 @@ func acceptRequest(typ reqType, hydraURL, challenge string, data interface{}) (s
 	if err != nil {
 		return "", err
 	}
+	if fakeTlsTermination {
+		r.Header.Add("X-Forwarded-Proto", "https")
+	}
+
 	r.Header.Set("Content-Type", "application/json")
 	resp, err := http.DefaultClient.Do(r)
 	if err != nil {

--- a/internal/hydra/login.go
+++ b/internal/hydra/login.go
@@ -14,18 +14,18 @@ import (
 // LoginReqDoer fetches information on the OAuth2 request and then accept or reject the requested authentication process.
 type LoginReqDoer struct {
 	hydraURL           string
-	fakeTlsTermination bool
+	fakeTLSTermination bool
 	rememberFor        int
 }
 
 // NewLoginReqDoer creates a LoginRequest.
-func NewLoginReqDoer(hydraURL string, fakeTlsTermination bool, rememberFor int) *LoginReqDoer {
-	return &LoginReqDoer{hydraURL: hydraURL, fakeTlsTermination: fakeTlsTermination, rememberFor: rememberFor}
+func NewLoginReqDoer(hydraURL string, fakeTLSTermination bool, rememberFor int) *LoginReqDoer {
+	return &LoginReqDoer{hydraURL: hydraURL, fakeTLSTermination: fakeTLSTermination, rememberFor: rememberFor}
 }
 
 // InitiateRequest fetches information on the OAuth2 request.
 func (lrd *LoginReqDoer) InitiateRequest(challenge string) (*ReqInfo, error) {
-	ri, err := initiateRequest(login, lrd.hydraURL, lrd.fakeTlsTermination, challenge)
+	ri, err := initiateRequest(login, lrd.hydraURL, lrd.fakeTLSTermination, challenge)
 	return ri, errors.Wrap(err, "failed to initiate login request")
 }
 
@@ -40,6 +40,6 @@ func (lrd *LoginReqDoer) AcceptLoginRequest(challenge string, remember bool, sub
 		RememberFor: lrd.rememberFor,
 		Subject:     subject,
 	}
-	redirectURI, err := acceptRequest(login, lrd.hydraURL, lrd.fakeTlsTermination, challenge, data)
+	redirectURI, err := acceptRequest(login, lrd.hydraURL, lrd.fakeTLSTermination, challenge, data)
 	return redirectURI, errors.Wrap(err, "failed to accept login request")
 }

--- a/internal/hydra/login.go
+++ b/internal/hydra/login.go
@@ -40,6 +40,6 @@ func (lrd *LoginReqDoer) AcceptLoginRequest(challenge string, remember bool, sub
 		RememberFor: lrd.rememberFor,
 		Subject:     subject,
 	}
-	redirectURI, err := acceptRequest(login, lrd.hydraURL, challenge, data)
+	redirectURI, err := acceptRequest(login, lrd.hydraURL, lrd.fakeTlsTermination, challenge, data)
 	return redirectURI, errors.Wrap(err, "failed to accept login request")
 }

--- a/internal/hydra/login.go
+++ b/internal/hydra/login.go
@@ -13,18 +13,19 @@ import (
 
 // LoginReqDoer fetches information on the OAuth2 request and then accept or reject the requested authentication process.
 type LoginReqDoer struct {
-	hydraURL    string
-	rememberFor int
+	hydraURL           string
+	fakeTlsTermination bool
+	rememberFor        int
 }
 
 // NewLoginReqDoer creates a LoginRequest.
-func NewLoginReqDoer(hydraURL string, rememberFor int) *LoginReqDoer {
-	return &LoginReqDoer{hydraURL: hydraURL, rememberFor: rememberFor}
+func NewLoginReqDoer(hydraURL string, fakeTlsTermination bool, rememberFor int) *LoginReqDoer {
+	return &LoginReqDoer{hydraURL: hydraURL, fakeTlsTermination: fakeTlsTermination, rememberFor: rememberFor}
 }
 
 // InitiateRequest fetches information on the OAuth2 request.
 func (lrd *LoginReqDoer) InitiateRequest(challenge string) (*ReqInfo, error) {
-	ri, err := initiateRequest(login, lrd.hydraURL, challenge)
+	ri, err := initiateRequest(login, lrd.hydraURL, lrd.fakeTlsTermination, challenge)
 	return ri, errors.Wrap(err, "failed to initiate login request")
 }
 

--- a/internal/hydra/login_test.go
+++ b/internal/hydra/login_test.go
@@ -60,7 +60,7 @@ func TestInitiateLoginRequest(t *testing.T) {
 			h := &testInitiateLoginHandler{reqInfo: tc.reqInfo, status: tc.status}
 			srv := httptest.NewServer(h)
 			defer srv.Close()
-			ldr := hydra.NewLoginReqDoer(srv.URL, 0)
+			ldr := hydra.NewLoginReqDoer(srv.URL, false, 0)
 
 			reqInfo, err := ldr.InitiateRequest(tc.challenge)
 
@@ -160,7 +160,7 @@ func TestAcceptLoginRequest(t *testing.T) {
 			h := &testAcceptLoginHandler{challenge: tc.challenge, status: tc.status, redirect: tc.redirect}
 			srv := httptest.NewServer(h)
 			defer srv.Close()
-			ldr := hydra.NewLoginReqDoer(srv.URL, tc.rememberFor)
+			ldr := hydra.NewLoginReqDoer(srv.URL, false, tc.rememberFor)
 
 			redirect, err := ldr.AcceptLoginRequest(tc.challenge, tc.remember, tc.subject)
 

--- a/internal/hydra/logout.go
+++ b/internal/hydra/logout.go
@@ -13,17 +13,18 @@ import (
 
 // LogoutReqDoer fetches information on the OAuth2 request and then accepts or rejects the requested logout process.
 type LogoutReqDoer struct {
-	hydraURL string
+	hydraURL           string
+	fakeTlsTermination bool
 }
 
 // NewLogoutReqDoer creates a LogoutRequest.
-func NewLogoutReqDoer(hydraURL string) *LogoutReqDoer {
-	return &LogoutReqDoer{hydraURL: hydraURL}
+func NewLogoutReqDoer(hydraURL string, fakeTlsTermination bool) *LogoutReqDoer {
+	return &LogoutReqDoer{hydraURL: hydraURL, fakeTlsTermination: fakeTlsTermination}
 }
 
 // InitiateRequest fetches information on the OAuth2 request.
 func (lrd *LogoutReqDoer) InitiateRequest(challenge string) (*ReqInfo, error) {
-	ri, err := initiateRequest(logout, lrd.hydraURL, challenge)
+	ri, err := initiateRequest(logout, lrd.hydraURL, lrd.fakeTlsTermination, challenge)
 	return ri, errors.Wrap(err, "failed to initiate logout request")
 }
 

--- a/internal/hydra/logout.go
+++ b/internal/hydra/logout.go
@@ -14,22 +14,22 @@ import (
 // LogoutReqDoer fetches information on the OAuth2 request and then accepts or rejects the requested logout process.
 type LogoutReqDoer struct {
 	hydraURL           string
-	fakeTlsTermination bool
+	fakeTLSTermination bool
 }
 
 // NewLogoutReqDoer creates a LogoutRequest.
-func NewLogoutReqDoer(hydraURL string, fakeTlsTermination bool) *LogoutReqDoer {
-	return &LogoutReqDoer{hydraURL: hydraURL, fakeTlsTermination: fakeTlsTermination}
+func NewLogoutReqDoer(hydraURL string, fakeTLSTermination bool) *LogoutReqDoer {
+	return &LogoutReqDoer{hydraURL: hydraURL, fakeTLSTermination: fakeTLSTermination}
 }
 
 // InitiateRequest fetches information on the OAuth2 request.
 func (lrd *LogoutReqDoer) InitiateRequest(challenge string) (*ReqInfo, error) {
-	ri, err := initiateRequest(logout, lrd.hydraURL, lrd.fakeTlsTermination, challenge)
+	ri, err := initiateRequest(logout, lrd.hydraURL, lrd.fakeTLSTermination, challenge)
 	return ri, errors.Wrap(err, "failed to initiate logout request")
 }
 
 // AcceptLogoutRequest accepts the requested logout process, and returns redirect URI.
 func (lrd *LogoutReqDoer) AcceptLogoutRequest(challenge string) (string, error) {
-	redirectURI, err := acceptRequest(logout, lrd.hydraURL, lrd.fakeTlsTermination, challenge, nil)
+	redirectURI, err := acceptRequest(logout, lrd.hydraURL, lrd.fakeTLSTermination, challenge, nil)
 	return redirectURI, errors.Wrap(err, "failed to accept logout request")
 }

--- a/internal/hydra/logout.go
+++ b/internal/hydra/logout.go
@@ -30,6 +30,6 @@ func (lrd *LogoutReqDoer) InitiateRequest(challenge string) (*ReqInfo, error) {
 
 // AcceptLogoutRequest accepts the requested logout process, and returns redirect URI.
 func (lrd *LogoutReqDoer) AcceptLogoutRequest(challenge string) (string, error) {
-	redirectURI, err := acceptRequest(logout, lrd.hydraURL, challenge, nil)
+	redirectURI, err := acceptRequest(logout, lrd.hydraURL, lrd.fakeTlsTermination, challenge, nil)
 	return redirectURI, errors.Wrap(err, "failed to accept logout request")
 }

--- a/internal/hydra/logout_test.go
+++ b/internal/hydra/logout_test.go
@@ -44,7 +44,7 @@ func TestInitiateLogoutRequest(t *testing.T) {
 			h := &testInitiateLogoutHandler{reqInfo: tc.reqInfo, status: tc.status}
 			srv := httptest.NewServer(h)
 			defer srv.Close()
-			ldr := hydra.NewLogoutReqDoer(srv.URL)
+			ldr := hydra.NewLogoutReqDoer(srv.URL, false)
 
 			reqInfo, err := ldr.InitiateRequest(tc.challenge)
 
@@ -126,7 +126,7 @@ func TestAcceptLogoutRequest(t *testing.T) {
 			h := &testAcceptLogoutHandler{challenge: tc.challenge, status: tc.status, redirect: tc.redirect}
 			srv := httptest.NewServer(h)
 			defer srv.Close()
-			ldr := hydra.NewLogoutReqDoer(srv.URL)
+			ldr := hydra.NewLogoutReqDoer(srv.URL, false)
 
 			redirect, err := ldr.AcceptLogoutRequest(tc.challenge)
 


### PR DESCRIPTION
## Proposed Changes

  - Adds FAKE_TLS_TERMINATION configuration variable
  - When configuration variable is enable requests to the hydra admin include the `X-Forwarded-Proto: http` header to fake TLS termination
  - This follows the similar implementation in the hydra CLI client: <https://github.com/ory/hydra/blob/24f91ab7038e4c612db5af86ff0f3ee5eb03c878/cmd/clients.go#L36>
  
## Use Case

 - Helps in situations where your installation has TLS termination (e.g. reverse proxy) and your werther installation is behind that proxy. such as kubernetes or docker installations.
  
  Please note that i am not a golang dev and am sorry for any errors in style/etc.
