### PR TITLE
identp: add support for requested audience pass through

### DIFF
--- a/internal/hydra/consent.go
+++ b/internal/hydra/consent.go
@@ -30,19 +30,21 @@ func (crd *ConsentReqDoer) InitiateRequest(challenge string) (*ReqInfo, error) {
 }
 
 // AcceptConsentRequest accepts the requested authentication process, and returns redirect URI.
-func (crd *ConsentReqDoer) AcceptConsentRequest(challenge string, remember bool, grantScope []string, idToken interface{}) (string, error) {
+func (crd *ConsentReqDoer) AcceptConsentRequest(challenge string, remember bool, grantScope []string, grantAudience []string, idToken interface{}) (string, error) {
 	type session struct {
 		IDToken interface{} `json:"id_token,omitempty"`
 	}
 	data := struct {
-		GrantScope  []string `json:"grant_scope"`
-		Remember    bool     `json:"remember"`
-		RememberFor int      `json:"remember_for"`
-		Session     session  `json:"session,omitempty"`
+		GrantScope    []string `json:"grant_scope"`
+		GrantAudience []string `json:"grant_access_token_audience"`
+		Remember      bool     `json:"remember"`
+		RememberFor   int      `json:"remember_for"`
+		Session       session  `json:"session,omitempty"`
 	}{
-		GrantScope:  grantScope,
-		Remember:    remember,
-		RememberFor: crd.rememberFor,
+		GrantScope:    grantScope,
+		GrantAudience: grantAudience,
+		Remember:      remember,
+		RememberFor:   crd.rememberFor,
 		Session: session{
 			IDToken: idToken,
 		},

--- a/internal/hydra/hydra.go
+++ b/internal/hydra/hydra.go
@@ -38,10 +38,11 @@ const (
 
 // ReqInfo contains information on an ongoing login or consent request.
 type ReqInfo struct {
-	Challenge       string   `json:"challenge"`
-	RequestedScopes []string `json:"requested_scope"`
-	Skip            bool     `json:"skip"`
-	Subject         string   `json:"subject"`
+	Challenge         string   `json:"challenge"`
+	RequestedScopes   []string `json:"requested_scope"`
+	RequestedAudience []string `json:"requested_access_token_audience"`
+	Skip              bool     `json:"skip"`
+	Subject           string   `json:"subject"`
 }
 
 func initiateRequest(typ reqType, hydraURL string, fakeTLSTermination bool, challenge string) (*ReqInfo, error) {

--- a/internal/identp/identp.go
+++ b/internal/identp/identp.go
@@ -219,7 +219,7 @@ func newLoginEndHandler(ra oa2LoginReqAcceptor, auther authenticator, tmplRender
 // InitiateRequest returns hydra.ErrChallengeExpired if the OAuth2 provider processed the challenge previously.
 type oa2ConsentReqProcessor interface {
 	InitiateRequest(challenge string) (*hydra.ReqInfo, error)
-	AcceptConsentRequest(challenge string, remember bool, grantScope []string, idToken interface{}) (string, error)
+	AcceptConsentRequest(challenge string, remember bool, grantScope []string, grantAudience []string, idToken interface{}) (string, error)
 }
 
 func newConsentHandler(rproc oa2ConsentReqProcessor, cfinder oidcClaimsFinder, claimScopes map[string]string) http.HandlerFunc {
@@ -277,7 +277,7 @@ func newConsentHandler(rproc oa2ConsentReqProcessor, cfinder oidcClaimsFinder, c
 				log.Debugw("Deleted the OIDC claim because it's not in requested scopes", "claim", claim)
 			}
 		}
-		redirectTo, err := rproc.AcceptConsentRequest(challenge, !ri.Skip, ri.RequestedScopes, claims)
+		redirectTo, err := rproc.AcceptConsentRequest(challenge, !ri.Skip, ri.RequestedScopes, ri.RequestedAudience, claims)
 		if err != nil {
 			log.Infow("Failed to accept a consent request to the OAuth2 provider", zap.Error(err), "scopes", ri.RequestedScopes, "claims", claims)
 			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)


### PR DESCRIPTION
## Proposed Changes

  - Adds support for passing through custom audience values as mentioned in the [docs](https://www.ory.sh/hydra/docs/advanced/)

This change allows clients to pass an `?audience=https://my.server.com` argument to the auth endpoint to customize the `aud` field of the access token. Without this change the consent handler doesn't pass it through and it has no effect.
