### PR TITLE
ldap: remove escape characters from search DN

### DIFF
--- a/internal/ldapclient/ldapclient.go
+++ b/internal/ldapclient/ldapclient.go
@@ -180,7 +180,8 @@ func (cli *Client) FindOIDCClaims(ctx context.Context, username string) (map[str
 
 	// User's roles is stored in LDAP as groups. We find all groups in a role's DN
 	// that include the user as a member.
-	entries, err := cn.SearchUserRoles(fmt.Sprintf("%s", details["dn"]), "dn", cli.RoleAttr)
+	sanitizedDN := strings.Replace(fmt.Sprintf("%s", details["dn"]), "\\", "", -1)
+	entries, err := cn.SearchUserRoles(sanitizedDN, "dn", cli.RoleAttr)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Names in "last, first" format end up with a backslash escape character which breaks searches

## Proposed Changes

  - Remove escape characters from the "dn" value returned from the info.

There may be a better way to deal with this problem but I don't have enough experience with the LDAP modules to understand how and when values include escape values. It seems strange that the escape character makes it into the response but it seems to.
