### PR TITLE
map roles claim to single list

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ cache:
     - "$GOPATH/pkg/mod"
     - "$GOPATH/bin"
 
-install: curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.16.0
+install: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.49.0
 
 script:
   - go test -v -coverprofile=coverage.txt ./...

--- a/README.md
+++ b/README.md
@@ -159,19 +159,34 @@ In the above example, Werther returns a response that contains the next roles:
     ```
 
 If your applications expect the roles claim to be an array of strings, for example Concourse or Argo CD,
-you can map groups to claims using with the environment variable `WERTHER_LDAP_FLAT_ROLE_CLAIMS`.
-In the above example, when the environment variable `WERTHER_LDAP_ROLE_BASEDN` equals to `ou=Dev,ou=AppRoles,dc=example,dc=com`
-and the `WERTHER_LDAP_FLAT_ROLE_CLAIMS` equals to `App1:https%3A%2F%2Fexample.com%2Fwerther%2Fclaims%2Froles%2Fapp1`
-(the name must be [URL encoded][uri-spec-encoding]), Werther returns one more role's claim.
-The role's claim `https://github.com/i-core/werther/claims/roles/app1` contains the roles as a string array.
+you can add groups to claims using with the environment variable `WERTHER_LDAP_FLAT_ROLE_CLAIMS`.
+When it is true Werther add corresponding claims for all the apps as an array of roles.
+
+Example 1:
+
+WERTHER_LDAP_FLAT_ROLE_CLAIMS=false
 
 ```json
 {
     "https://github.com/i-core/werther/claims/roles": {
-        "App1": ["role1", "role3"],
-        "App2": ["role1", "role4"]
+        "App1": ["role1", "role2"],
+        "App2": ["role3", "role4"]
+    }
+}
+```
+
+Example 2:
+
+WERTHER_LDAP_FLAT_ROLE_CLAIMS=true
+
+```json
+{
+    "https://github.com/i-core/werther/claims/roles": {
+        "App1": ["role1", "role2"],
+        "App2": ["role3", "role4"]
     },
-    "https://github.com/i-core/werther/claims/roles/app1": ["role1", "role3"]
+    "https://github.com/i-core/werther/claims/roles/App1": ["role1", "role2"],
+    "https://github.com/i-core/werther/claims/roles/App2": ["role3", "role4"]
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ werther -h
 
 In LDAP user's roles are groups in which a user is a member.
 
-The environment variable `WERTHER_LDAP_ROLE_DN` is a DN for searching roles.
+The environment variable `WERTHER_LDAP_ROLE_BASEDN` is a DN for searching roles.
 
 For example, create an OU that repserents an application, and then in the created OU
 create groups that represent application's roles:
@@ -83,7 +83,7 @@ dc=com
             |-- cn=app1_role2 (objectClass="group", description="role2")
 ```
 
-Run Werther with the environment variable `WERTHER_LDAP_ROLE_DN`
+Run Werther with the environment variable `WERTHER_LDAP_ROLE_BASEDN`
 that equals to `ou=AppRoles,dc=example,dc=com`.
 
 In the above example Werther returns user's roles as a value
@@ -139,7 +139,7 @@ A name of a LDAP attribute is specified using the environment variable `WERTHER_
 and has the default value `description`.
 
 In the above example, Werther returns a response that contains the next roles:
-* when the environment variable `WERTHER_LDAP_ROLE_DN` equals to `ou=Test,ou=AppRoles,dc=example,dc=com`:
+* when the environment variable `WERTHER_LDAP_ROLE_BASEDN` equals to `ou=Test,ou=AppRoles,dc=example,dc=com`:
     ```json
     {
         "https://github.com/i-core/werther/claims/roles": {
@@ -148,7 +148,7 @@ In the above example, Werther returns a response that contains the next roles:
         }
     }
     ```
-* when the environment variable `WERTHER_LDAP_ROLE_DN` equals to `ou=Dev,ou=AppRoles,dc=example,dc=com`:
+* when the environment variable `WERTHER_LDAP_ROLE_BASEDN` equals to `ou=Dev,ou=AppRoles,dc=example,dc=com`:
     ```json
     {
         "https://github.com/i-core/werther/claims/roles": {
@@ -157,6 +157,23 @@ In the above example, Werther returns a response that contains the next roles:
         }
     }
     ```
+
+If your applications expect the roles claim to be an array of strings, for example Concourse or Argo CD,
+you can map groups to claims using with the environment variable `WERTHER_LDAP_FLAT_ROLE_CLAIMS`.
+In the above example, when the environment variable `WERTHER_LDAP_ROLE_BASEDN` equals to `ou=Dev,ou=AppRoles,dc=example,dc=com`
+and the `WERTHER_LDAP_FLAT_ROLE_CLAIMS` equals to `App1:https%3A%2F%2Fexample.com%2Fwerther%2Fclaims%2Froles%2Fapp1`
+(the name must be [URL encoded][uri-spec-encoding]), Werther returns one more role's claim.
+The role's claim `https://github.com/i-core/werther/claims/roles/app1` contains the roles as a string array.
+
+```json
+{
+    "https://github.com/i-core/werther/claims/roles": {
+        "App1": ["role1", "role3"],
+        "App2": ["role1", "role4"]
+    },
+    "https://github.com/i-core/werther/claims/roles/app1": ["role1", "role3"]
+}
+```
 
 ## UI customization
 

--- a/cmd/werther/main.go
+++ b/cmd/werther/main.go
@@ -64,6 +64,21 @@ func main() {
 		os.Exit(1)
 	}
 
+	for k, v := range cnf.LDAP.FlatRoleClaims {
+		if _, ok := cnf.Identp.ClaimScopes[v]; !ok {
+			fmt.Fprintf(os.Stderr, "Flat role claim %q has no mapping to an OpenID Connect scope\n", v)
+			os.Exit(1)
+		}
+
+		roleClaim, err := url.QueryUnescape(v)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to unescape FlatRoleClaims: %s %s\n", v, err)
+			os.Exit(1)
+		}
+
+		cnf.LDAP.FlatRoleClaims[k] = roleClaim
+	}
+
 	logFunc := zap.NewProduction
 	if cnf.DevMode {
 		logFunc = zap.NewDevelopment

--- a/internal/identp/identp_test.go
+++ b/internal/identp/identp_test.go
@@ -451,7 +451,7 @@ func TestHandleConsent(t *testing.T) {
 					return tc.claims, tc.wantFindErr
 				},
 			}
-			handler := nosurf.New(newConsentHandler(rproc, cfinder, nil))
+			handler := nosurf.New(newConsentHandler(rproc, cfinder, nil, "rc"))
 			handler.ExemptPath("/consent")
 			handler.ServeHTTP(rr, r)
 

--- a/internal/ldapclient/ldapclient.go
+++ b/internal/ldapclient/ldapclient.go
@@ -229,13 +229,11 @@ func (cli *Client) FindOIDCClaims(ctx context.Context, username string) ([]Claim
 		roles[appID] = appRoles
 	}
 
-	if len(roles) > 0 {
-		claims = append(claims, Claim{cli.RoleClaim, cli.RoleClaim, roles})
+	claims = append(claims, Claim{cli.RoleClaim, cli.RoleClaim, roles})
 
-		if cli.FlatRoleClaims {
-			for appID, appRoles := range roles {
-				claims = append(claims, Claim{cli.RoleClaim, cli.RoleClaim + "/" + appID, appRoles})
-			}
+	if cli.FlatRoleClaims {
+		for appID, appRoles := range roles {
+			claims = append(claims, Claim{cli.RoleClaim, cli.RoleClaim + "/" + appID, appRoles})
 		}
 	}
 

--- a/internal/ldapclient/ldapclient_test.go
+++ b/internal/ldapclient/ldapclient_test.go
@@ -309,7 +309,8 @@ func TestFindOIDCClaims(t *testing.T) {
 			attrClaims: map[string]string{"dn": "name", "a": "claimA", "b": "claimB"},
 			want: []Claim{{"claimA", "claimA", "valA"},
 				{"claimB", "claimB", "valB"},
-				{"name", "name", "user1"}},
+				{"name", "name", "user1"},
+				{"test-roles-claim", "test-roles-claim", make(map[string]interface{})}},
 		},
 		{
 			name:       "skip claim if no attribute",
@@ -317,7 +318,8 @@ func TestFindOIDCClaims(t *testing.T) {
 			user:       "user1",
 			attrClaims: map[string]string{"dn": "name", "a": "claimA", "d": "claimD"},
 			want: []Claim{{"claimA", "claimA", "valA"},
-				{"name", "name", "user1"}},
+				{"name", "name", "user1"},
+				{"test-roles-claim", "test-roles-claim", make(map[string]interface{})}},
 		},
 		{
 			name:       "claims with roles for one application",
@@ -356,7 +358,8 @@ func TestFindOIDCClaims(t *testing.T) {
 			connector:  newTestConnector("ep1", &testConn{users: users}),
 			user:       "user6",
 			attrClaims: map[string]string{"dn": "name"},
-			want:       []Claim{{"name", "name", "user6"}},
+			want: []Claim{{"name", "name", "user6"},
+				{"test-roles-claim", "test-roles-claim", make(map[string]interface{})}},
 		},
 		{
 			name:       "auth with invalid service account",
@@ -376,14 +379,15 @@ func TestFindOIDCClaims(t *testing.T) {
 			attrClaims: map[string]string{"dn": "name", "a": "claimA", "b": "claimB"},
 			want: []Claim{{"claimA", "claimA", "valA"},
 				{"claimB", "claimB", "valB"},
-				{"name", "name", "user1"}},
+				{"name", "name", "user1"},
+				{"test-roles-claim", "test-roles-claim", make(map[string]interface{})}},
 		},
 		{
 			name:           "skip flat role if no app",
 			connector:      newTestConnector("ep1", &testConn{users: users}),
 			user:           "user1",
 			flatRoleClaims: true,
-			want:           []Claim{},
+			want:           []Claim{{"test-roles-claim", "test-roles-claim", make(map[string]interface{})}},
 		},
 		{
 			name:           "flat roles for one application",

--- a/internal/web/web.go
+++ b/internal/web/web.go
@@ -124,7 +124,7 @@ func (r *HTMLRenderer) RenderTemplate(w http.ResponseWriter, req *http.Request, 
 	}
 
 	var langPrefs []langPref
-	if acceptLang := req.Header.Get(http.CanonicalHeaderKey("Accept-Language")); acceptLang != "" {
+	if acceptLang := req.Header.Get("Accept-Language"); acceptLang != "" {
 		var tags []language.Tag
 		var weights []float32
 		tags, weights, err = language.ParseAcceptLanguage(acceptLang)

--- a/internal/web/web_test.go
+++ b/internal/web/web_test.go
@@ -135,7 +135,7 @@ func TestHTMLRenderer(t *testing.T) {
 
 			rr := httptest.NewRecorder()
 			req := httptest.NewRequest(http.MethodGet, "http://localhost", nil)
-			req.Header.Set(http.CanonicalHeaderKey("Accept-Language"), "ru-RU,ru;q=0.9,en-US;q=0.8,en;q=0.7")
+			req.Header.Set("Accept-Language", "ru-RU,ru;q=0.9,en-US;q=0.8,en;q=0.7")
 			err = r.RenderTemplate(rr, req, "login.tmpl", tc.data)
 
 			if tc.wantErr != nil {


### PR DESCRIPTION
Fixes #14

## Proposed Changes

- You can map groups to roles claim using with the environment variable WERTHER_LDAP_FLAT_ROLE_CLAIMS